### PR TITLE
Call super in beforeModel hook

### DIFF
--- a/my-frontend/app/routes/application.js
+++ b/my-frontend/app/routes/application.js
@@ -4,6 +4,7 @@ import ApplicationRouteMixin from 'simple-auth/mixins/application-route-mixin';
 export default Ember.Route.extend(
     ApplicationRouteMixin, {
     beforeModel: function () {
+        this._super.apply(this, arguments);
         return this.csrf.fetchToken();
     }
 });


### PR DESCRIPTION
Use this._super to call the application routes beforeModel hook so the ApplicationRouteMixin works properly. (Transistions after login etc.)
